### PR TITLE
Fix/update set output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: debianmaster/actions-k3s@master
+    - uses: rohan397/actions-k3s@master
       id: k3s
       with:
         version: 'latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: rohan397/actions-k3s@fix/update-set-output
+    - uses: debianmaster/actions-k3s@master
       id: k3s
       with:
         version: 'latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: rohan397/actions-k3s@master
+    - uses: rohan397/actions-k3s@fix/update-set-output
       id: k3s
       with:
         version: 'latest'

--- a/action.yml
+++ b/action.yml
@@ -12,5 +12,5 @@ branding:
   icon: "box"
   color: "green"
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     default: 'v1.0.0'
 outputs:
   kubeconfig: # id of output
-    description: 'location of Kubeconfig'
+    description: 'Kubeconfig location'
 branding:
   icon: "box"
   color: "green"

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     default: 'v1.0.0'
 outputs:
   kubeconfig: # id of output
-    description: 'Kubeconfig location'
+    description: 'location of Kubeconfig'
 branding:
   icon: "box"
   color: "green"

--- a/dist/index.js
+++ b/dist/index.js
@@ -278,33 +278,6 @@ function setOutput(name, value) {
     command_1.issueCommand('set-env', { name }, convertedVal);
   }
 }
-  /*
-    const filePath = process.env['GITHUB_OUTPUT'] || ''
-  if (filePath) {
-    return issueFileCommand('OUTPUT', prepareKeyValueMessage(name, value))
-  }
-
-  process.stdout.write(os.EOL)
-  issueCommand('set-output', {name}, value)
-  issueCommand('set-output', {name}, toCommandValue(value))
-}
-
-  */
-  /*
-    const convertedVal = utils_1.toCommandValue(val);
-    process.env[name] = convertedVal;
-    const filePath = process.env['GITHUB_ENV'] || '';
-    if (filePath) {
-        const delimiter = '_GitHubActionsFileCommandDelimeter_';
-        const commandValue = `${name}<<${delimiter}${os.EOL}${convertedVal}${os.EOL}${delimiter}`;
-        file_command_1.issueCommand('ENV', commandValue);
-    }
-    else {
-        command_1.issueCommand('set-env', { name }, convertedVal);
-    }
-}
-  */
-}
 exports.setOutput = setOutput;
 /**
  * Enables or disables the echoing of commands into stdout for the rest of the step.

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,3 +1,5 @@
+const core = require('@actions/core');
+
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
@@ -265,8 +267,9 @@ exports.getBooleanInput = getBooleanInput;
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function setOutput(name, value) {
-    process.stdout.write(os.EOL);
-    command_1.issueCommand('set-output', { name }, value);
+  process.stdout.write(os.EOL);
+  core.setOutput(name, value)
+    //command_1.issueCommand('set-output', { name }, value);
 }
 exports.setOutput = setOutput;
 /**

--- a/dist/index.js
+++ b/dist/index.js
@@ -265,12 +265,12 @@ exports.getBooleanInput = getBooleanInput;
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function setOutput(name, value) {
-  const convertedVal = utils_1.toCommandValue(val);
+  const convertedVal = utils_1.toCommandValue(value);
   const filePath = process.env['GITHUB_OUTPUT'] || ''
 
   if (filePath) {
     const delimiter = '_GitHubActionsFileCommandDelimeter_';
-    const commandValue = `${name}<<${delimiter}${os.EOL}${value}${os.EOL}${delimiter}`;
+    const commandValue = `${name}<<${delimiter}${os.EOL}${convertedVal}${os.EOL}${delimiter}`;
     file_command_1.issueCommand('OUTPUT', commandValue);
   } 
   else {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,5 +1,3 @@
-const core = require('@actions/core');
-
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
@@ -267,9 +265,45 @@ exports.getBooleanInput = getBooleanInput;
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function setOutput(name, value) {
-  process.stdout.write(os.EOL);
-  core.setOutput(name, value)
-    //command_1.issueCommand('set-output', { name }, value);
+  const convertedVal = utils_1.toCommandValue(val);
+  const filePath = process.env['GITHUB_OUTPUT'] || ''
+
+  if (filePath) {
+    const delimiter = '_GitHubActionsFileCommandDelimeter_';
+    const commandValue = `${name}<<${delimiter}${os.EOL}${value}${os.EOL}${delimiter}`;
+    file_command_1.issueCommand('OUTPUT', commandValue);
+  } 
+  else {
+    process.stdout.write(os.EOL);
+    command_1.issueCommand('set-env', { name }, convertedVal);
+  }
+}
+  /*
+    const filePath = process.env['GITHUB_OUTPUT'] || ''
+  if (filePath) {
+    return issueFileCommand('OUTPUT', prepareKeyValueMessage(name, value))
+  }
+
+  process.stdout.write(os.EOL)
+  issueCommand('set-output', {name}, value)
+  issueCommand('set-output', {name}, toCommandValue(value))
+}
+
+  */
+  /*
+    const convertedVal = utils_1.toCommandValue(val);
+    process.env[name] = convertedVal;
+    const filePath = process.env['GITHUB_ENV'] || '';
+    if (filePath) {
+        const delimiter = '_GitHubActionsFileCommandDelimeter_';
+        const commandValue = `${name}<<${delimiter}${os.EOL}${convertedVal}${os.EOL}${delimiter}`;
+        file_command_1.issueCommand('ENV', commandValue);
+    }
+    else {
+        command_1.issueCommand('set-env', { name }, convertedVal);
+    }
+}
+  */
 }
 exports.setOutput = setOutput;
 /**


### PR DESCRIPTION
Running the action would give two warnings - one that node12 is deprecated and needs to be upgraded to node16, and the second that the set-output command is also deprecated and needs to be replaced to follow the new syntax (link is [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)).

This PR updates the version of node to 16 and also changes the way the actions sets outputs. 